### PR TITLE
Fixed incorrect imports (Docs)

### DIFF
--- a/src/routes/remote/home/home.svx
+++ b/src/routes/remote/home/home.svx
@@ -28,8 +28,8 @@ This part of the lib provides 2 additional functions
 
 ````svelte
 <script lang="ts">
-    import { DataHandler, type State 
-             DataTable, Th, ThFilter } from '@vincjo/datatables/remote'
+    import { DataHandler, type State, 
+             Datatable, Th, ThFilter } from '@vincjo/datatables/remote'
     import { myLoadFunction } from './my-api-helper'
 
     const handler = new DataHandler([], { rowsPerPage: 10 })


### PR DESCRIPTION
The import was defined as DataTable instead of datatable, also missing a comma after State.