### PR TITLE
docs: Fix join filters with empty string

### DIFF
--- a/src/routes/remote/basic-usage/usage.svx
+++ b/src/routes/remote/basic-usage/usage.svx
@@ -68,7 +68,7 @@ const getParams = ({ offset, rowsPerPage, search, sort, filters }: State) => {
         params += `&sort=${sort.orderBy}&order=${sort.direction}`
     }
     if (filters) {
-        params += filters.map(({ filterBy, value }) => `&${filterBy}=${value}`).join()
+        params += filters.map(({ filterBy, value }) => `&${filterBy}=${value}`).join('')
     }
     return params
 }

--- a/src/routes/remote/examples/todo-api/api.ts
+++ b/src/routes/remote/examples/todo-api/api.ts
@@ -20,7 +20,7 @@ const getParams = (state: State) => {
         params += `&_sort=${sort.orderBy}&_order=${sort.direction}`
     }
     if (filters) {
-        params += filters.map(({ filterBy, value }) => `&${filterBy}=${value}`).join()
+        params += filters.map(({ filterBy, value }) => `&${filterBy}=${value}`).join('')
     }
     if (search) {
         params += `&q=${search}`


### PR DESCRIPTION
The default `join()` function will concatenating all of the filters value with commas instead of empty string. If more than one column filters parameter is given, the fetch query become something like:

id=1`,`&title=query`,`&completed=query

Giving *join* `separator` parameter with empty string fix the issue.