### PR TITLE
docs: ssr exemple

### DIFF
--- a/src/routes/server/examples/+layout.svelte
+++ b/src/routes/server/examples/+layout.svelte
@@ -26,6 +26,12 @@
             description: `A Pokemon list. Source: Poke API`,
             tag: ['rows per page', 'pagination', 'row count']
         },
+        {
+            title: `SSR User API`,
+            page: 'ssr-user',
+            description: `SSR example with pagination and row count`,
+            tag: ['rows per page', 'pagination', 'row count']
+        },
         // {
         //     title: `Beer API`,
         //     page: 'beer-api',

--- a/src/routes/server/examples/ssr-user/+page.server.ts
+++ b/src/routes/server/examples/ssr-user/+page.server.ts
@@ -1,0 +1,19 @@
+import type { PageServerLoad } from "./$types";
+
+export const load = (async ({ url }) => {
+  const searchParams = url.searchParams;
+  const page = parseInt(searchParams.get("page")) || 1;
+  const pageSize = parseInt(searchParams.get("pageSize")) || 15;
+
+  const limit = pageSize;
+  const skip = (page - 1) * pageSize;
+  const response = await fetch(
+    `https://dummyjson.com/users?limit=${limit}&skip=${skip}`
+  );
+  const dataset = await response.json();
+  // console.log("dataset", dataset);
+  return {
+    rows: dataset.users,
+    count: dataset.total,
+  };
+}) satisfies PageServerLoad;

--- a/src/routes/server/examples/ssr-user/+page.svelte
+++ b/src/routes/server/examples/ssr-user/+page.svelte
@@ -1,0 +1,87 @@
+
+<script lang="ts">
+    import { navigating } from '$app/stores';
+    import type { PageData } from './$types'
+  
+    let { data }: { data: PageData } = $props()
+    import {
+      TableHandler,
+      Datatable,
+      ThSort,
+      ThFilter,
+      Pagination,
+      RowsPerPage,
+      Search,
+      Th,
+      type State,
+    } from '$lib/src/server'
+    import { SSRFilters } from './params.svelte';
+  
+    const filters = new SSRFilters()
+  
+    const table = new TableHandler(data.rows, {
+      rowsPerPage: 10,
+      totalRows: data.count,
+    })
+  
+    table.load(async s => {
+      console.log(s)
+      filters.fromState(s)
+      await $navigating?.complete
+      return data.rows
+    })
+  </script>
+  
+  <Datatable {table}>
+    {#snippet header()}
+      <Search {table} />
+      <RowsPerPage {table} />
+    {/snippet}
+    <table>
+        <thead>
+            <tr>
+                <Th>ID</Th>
+                <Th>Avatar</Th>
+                <Th>Fristname</Th>
+                <Th>Lastname</Th>
+                <Th>Age</Th>
+                <Th>Gender</Th>
+                <Th>Height / Weight</Th>
+            </tr>
+        </thead>
+        <tbody>
+            {#each table.rows as row}
+                <tr>
+                    <td>{row.id}</td>
+                    <td>
+                        <img src="{row.image}" alt="avatar" />
+                    </td>
+                    <td>{row.firstName}</td>
+                    <td>{row.lastName}</td>
+                    <td>{row.age}</td>
+                    <td>{row.gender}</td>
+                    <td>
+                        {String(row.height / 100).substring(0, 4)}m / {String(row.weight).substring(0, 4)}kg
+                    </td>
+                </tr>
+            {/each}
+        </tbody>
+    </table>
+    {#snippet footer()}
+      <div></div>
+      <Pagination {table} />
+    {/snippet}
+  </Datatable>
+  
+  <style>
+    b {
+      color: var(--r-primary);
+      font-weight: normal;
+      line-height: 16px;
+      white-space: break-spaces;
+    }
+    span {
+      padding-left: 8px;
+    }
+  </style>
+  

--- a/src/routes/server/examples/ssr-user/params.svelte.ts
+++ b/src/routes/server/examples/ssr-user/params.svelte.ts
@@ -1,0 +1,75 @@
+import { page, navigating } from "$app/stores";
+import { get } from "svelte/store";
+import { goto } from "$app/navigation";
+import type { State } from "$lib/server";
+
+export class SSRFilters {
+  Filters = $derived.by(() => get(page).url);
+
+  constructor() {
+    console.log("Filters", this.Filters);
+  }
+
+  get(name: string) {
+    return this.Filters.searchParams.get(name);
+  }
+
+  update(filters: Record<string, string>) {
+    const url = new URL(this.Filters);
+    Object.entries(filters).forEach(([name, value]) => {
+      if (!value) {
+        url.searchParams.delete(name);
+      }
+      if (value !== "") url.searchParams.set(name, value);
+      else url.searchParams.delete(name);
+    });
+
+    if (typeof window !== "undefined") {
+      goto(url, { keepFocus: true });
+    }
+  }
+
+  fromState(s: State) {
+    const filters = s.filters ?? [];
+    const sort = s.sort;
+    const page = s.currentPage;
+    const rowsPerPage = s.rowsPerPage;
+
+
+    const url = new URL(this.Filters);
+    for (const { field, value } of filters) {
+      console.log("field", field, value);
+      url.searchParams.set(field.toString(), value.toString());
+    }
+    if (sort?.field && sort?.direction) {
+      console.log("sort", sort);
+      url.searchParams.set("sort_id", sort.field?.toString());
+      url.searchParams.set("sort_direction", sort.direction);
+    }
+    if (page) {
+      url.searchParams.set("page", page.toString());
+    }
+    if (rowsPerPage) {
+      url.searchParams.set("pageSize", rowsPerPage.toString());
+    }
+
+    if (typeof window !== "undefined") {
+      goto(url, { keepFocus: true });
+    }
+  }
+
+  clear(...params: string[]) {
+    const url = new URL(this.Filters);
+    params.forEach((p) => url.searchParams.delete(p));
+
+    if (typeof window !== "undefined") {
+      goto(url, { keepFocus: true });
+    }
+  }
+
+  isFiltered(...params: string[]) {
+    return (
+      params.length > 0 && params.some((p) => this.Filters.searchParams.has(p))
+    );
+  }
+}


### PR DESCRIPTION
Hey, I been playing with your library for a while and to be honest its my new favorite table library, after months of experiments with diferent ones, but I think its possible to simplify loading data from the server, using only sveltekit load functions

From sveltekit docs:

When do load functions rerun?

It calls url.searchParams.get(...), url.searchParams.getAll(...) or url.searchParams.has(...) and the parameter in question changes. Accessing other properties of url.searchParams will have the same effect as accessing url.search.



In my personal projects using drizzle I do something like:

```ts
/* eslint-disable @typescript-eslint/no-unused-vars */
import type { PageServerLoad } from './$types'

import * as schema from '$db/schema'
import {
  withPagination,
  withOrderBy,
  getSQLiteColumn,
  getOrderBy,
} from '$db/utils'
import { db } from '$db'
import { and, eq, getTableColumns, SQL, count, like } from 'drizzle-orm'

export const load = (async ({ url }) => {
  const { searchParams } = url
  const page = Number(searchParams.get('page') ?? 1)
  const pageSize = Number(searchParams.get('pageSize') ?? 10)

  const username = searchParams.get('username')
  const email = searchParams.get('email')

  const sortId = searchParams.get('sort_id')
  const sortOrder = searchParams.get('sort_direction')

  let query = db
    .select()
    .from(schema.userTable)
    .where(
      and(
        username ? like(schema.userTable.username, `%${username}%`) : undefined,
        email ? like(schema.userTable.email, `%${email}%`) : undefined,
      ),
    )
    .$dynamic()

  if (sortId && sortOrder) {
    query = withOrderBy(
      query,
      getSQLiteColumn(schema.userTable, sortId),
      sortOrder,
    )
  }

  try {
    const rows = await withPagination(query, page, pageSize)

    console.log(rows)

    const total = await db.select({ count: count() }).from(schema.userTable)

    return { rows: rows ?? [], count: total[0].count }
  } catch (error) {
    console.error(error)
    return { rows: [], count: 0 }
  }
}) satisfies PageServerLoad


```