### PR TITLE
feat: init values

### DIFF
--- a/src/lib/src/client/TableHandler.svelte.ts
+++ b/src/lib/src/client/TableHandler.svelte.ts
@@ -73,9 +73,9 @@ export default class TableHandler<T extends Row = any> extends AbstractTableHand
         }
     }
 
-    public createSearch(scope?: Field<T>[]): SearchBuilder<T>
+    public createSearch(scope?: Field<T>[], value?: string): SearchBuilder<T>
     {
-        return new SearchBuilder(this.searchHandler, scope)
+        return new SearchBuilder(this.searchHandler, scope, value)
     }
 
     public clearSearch(): void
@@ -90,9 +90,9 @@ export default class TableHandler<T extends Row = any> extends AbstractTableHand
         return new RecordFilterBuilder(records)
     }
 
-    public createSort(field: Field<T>, params?: { locales: Intl.LocalesArgument, options: Intl.CollatorOptions}): SortBuilder<T>
+    public createSort(field: Field<T>, init?: 'asc' | 'desc', params?: { locales: Intl.LocalesArgument, options: Intl.CollatorOptions}): SortBuilder<T>
     {
-        return new SortBuilder(this.sortHandler, field, params)
+        return new SortBuilder(this.sortHandler, field, params, init)
     }
 
     public clearSort()
@@ -112,9 +112,9 @@ export default class TableHandler<T extends Row = any> extends AbstractTableHand
         return new AdvancedFilterBuilder(this.filterHandler, field, check)
     }
 
-    public createFilter(field: Field<T>, check?: Check): FilterBuilder<T>
+    public createFilter(field: Field<T>, value?: string, check?: Check): FilterBuilder<T>
     {
-        return new FilterBuilder(this.filterHandler, field, check)
+        return new FilterBuilder(this.filterHandler, field, check, value)
     }
 
     public createQuery(): QueryBuilder<T>

--- a/src/lib/src/client/builders/FilterBuilder.svelte.ts
+++ b/src/lib/src/client/builders/FilterBuilder.svelte.ts
@@ -10,11 +10,15 @@ export default class FilterBuilder<Row>
     private field           : Field<Row>
     private check           : Check
 
-    constructor(filterHandler: FilterHandler<Row>, field: Field<Row>, check?: Check)
+    constructor(filterHandler: FilterHandler<Row>, field: Field<Row>, check?: Check, value?: string)
     {
         this.filterHandler  = filterHandler
         this.field          = field
         this.check          = check ?? comparator.isLike
+        if (value) {
+            this.value = value
+            this.filterHandler.set(this.value, this.field, this.check, this.id)
+        }
         this.cleanup()
     }
 

--- a/src/lib/src/client/builders/SearchBuilder.svelte.ts
+++ b/src/lib/src/client/builders/SearchBuilder.svelte.ts
@@ -7,10 +7,14 @@ export default class SearchBuilder<Row>
     private scope           : Field<Row>[]
     private searchHandler   : SearchHandler<Row>
 
-    constructor(searchHandler: SearchHandler<Row>, scope?: Field<Row>[])
+    constructor(searchHandler: SearchHandler<Row>, scope?: Field<Row>[], value?: string)
     {
         this.searchHandler  = searchHandler
         this.scope          = scope
+        if (value) {
+            this.value = value
+            this.searchHandler.set(this.value, this.scope)
+        }
         this.cleanup()
     }
 

--- a/src/lib/src/client/builders/SortBuilder.svelte.ts
+++ b/src/lib/src/client/builders/SortBuilder.svelte.ts
@@ -11,11 +11,14 @@ export default class SortBuilder<Row>
     private field           : Field<Row>
     private params          : SortParams
 
-    constructor(sortHandler: SortHandler<Row>, field: Field<Row>, params: SortParams)
+    constructor(sortHandler: SortHandler<Row>, field: Field<Row>, params: SortParams, init?: 'asc' | 'desc')
     {
         this.sortHandler    = sortHandler
         this.field          = field
         this.params         = params ?? {}
+        if (init) {
+            this.sortHandler.init(this.field, this.id, init)
+        }
     }
 
     public set()

--- a/src/lib/src/client/handlers/SortHandler.svelte.ts
+++ b/src/lib/src/client/handlers/SortHandler.svelte.ts
@@ -12,6 +12,12 @@ export default class SortHandler<Row>
         this.backup = []
     }
 
+    public init(field: Field<Row>, id: string, direction: 'asc' | 'desc')
+    {
+        const { callback, key } = parse(field, id)
+        this.table['sort'] = { id, callback, direction, key }
+    }
+
     public set(field: Field<Row>, id: string, params: SortParams = {})
     {
         if (this.table['sort'].id !== id) {

--- a/src/lib/src/server/TableHandler.svelte.ts
+++ b/src/lib/src/server/TableHandler.svelte.ts
@@ -71,17 +71,17 @@ export default class TableHandler<T extends Row = any> extends AbstractTableHand
         this.searchHandler.clear()
     }
 
-    public createSearch(): SearchBuilder<T>
+    public createSearch(value?: string): SearchBuilder<T>
     {
-        return new SearchBuilder(this)
+        return new SearchBuilder(this, value)
     }
 
-    public createSort(field: Field<T>): SortBuilder<T>
+    public createSort(field: Field<T>, init?: 'asc' | 'desc'): SortBuilder<T>
     {
         if (typeof field === 'function') {
             throw new Error(`Invalid field argument: ${String(field)}. Function type arguments are not allowed in server-side mode`)
         }
-        return new SortBuilder(this.sortHandler, field)
+        return new SortBuilder(this.sortHandler, field, init)
     }
 
     public clearFilters(): void
@@ -90,12 +90,12 @@ export default class TableHandler<T extends Row = any> extends AbstractTableHand
         this.invalidate()
     }
 
-    public createFilter(field: Field<T>): FilterBuilder<T>
+    public createFilter(field: Field<T>, value?: string): FilterBuilder<T>
     {
         if (typeof field === 'function') {
             throw new Error(`Invalid field argument: ${String(field)}. Function type arguments are not allowed in server-side mode`)
         }
-        return new FilterBuilder(this.filterHandler, field)
+        return new FilterBuilder(this.filterHandler, field, value)
     }
 
     public select(value: T[keyof T])

--- a/src/lib/src/server/builders/FilterBuilder.svelte.ts
+++ b/src/lib/src/server/builders/FilterBuilder.svelte.ts
@@ -7,16 +7,21 @@ export default class FilterBuilder<Row>
     private filterHandler   : FilterHandler<Row>
     private field           : keyof Row
 
-    constructor(filterHandler: FilterHandler<Row>, field: keyof Row)
+    constructor(filterHandler: FilterHandler<Row>, field: keyof Row, value?: string)
     {
         this.filterHandler  = filterHandler
         this.field          = field
+        if (value) {
+            this.value = value
+            this.filterHandler.set(this.value, this.field)
+        }
         this.cleanup()
     }
 
-    public set()
+    public set(invalidate: boolean = true)
     {
         this.filterHandler.set(this.value, this.field)
+        if (!invalidate) return
 		clearTimeout(this.timeout)
 		this.timeout = setTimeout( () => {
             this.filterHandler['table'].invalidate()

--- a/src/lib/src/server/builders/SearchBuilder.svelte.ts
+++ b/src/lib/src/server/builders/SearchBuilder.svelte.ts
@@ -6,18 +6,23 @@ export default class SearchBuilder<Row>
     private timeout         = undefined
     private table           : TableHandler<Row>
 
-    constructor(table: TableHandler<Row>)
+    constructor(table: TableHandler<Row>, value?: string)
     {
         this.table = table
+        if (value) {
+            this.value = value
+            this.table['search'] = value
+        }
         this.cleanup()
     }
 
-    public set()
+    public set(invalidate: boolean = true)
     {
         this.table['search'] = this.value
+        if (!invalidate) return
         clearTimeout(this.timeout)
         this.timeout = setTimeout( () => {
-            this.table.invalidate()
+            this.table.setPage(1)
         }, 400)
     }
 

--- a/src/lib/src/server/builders/SortBuilder.svelte.ts
+++ b/src/lib/src/server/builders/SortBuilder.svelte.ts
@@ -7,10 +7,13 @@ export default class SortBuilder<Row>
     public  isActive    = $derived<boolean>(this.createIsActive())
     public  direction   = $derived<'asc' | 'desc'>(this.createDirection())
 
-    constructor(sortHandler: SortHandler<Row>, field: keyof Row)
+    constructor(sortHandler: SortHandler<Row>, field: keyof Row, init?: 'asc' | 'desc')
     {
         this.sortHandler = sortHandler
         this.field       = field
+        if (init) {
+            this.sortHandler.init(this.field, init)
+        }
     }
 
     public set()

--- a/src/lib/src/server/handlers/SortHandler.svelte.ts
+++ b/src/lib/src/server/handlers/SortHandler.svelte.ts
@@ -9,6 +9,11 @@ export default class SortHandler<Row>
         this.table = table
     }
 
+    public init(field: keyof Row, direction: 'asc' | 'desc')
+    {
+        this.table['sort'] = { field, direction }
+    }
+
     public set(field: keyof Row)
     {
         const sort = this.table['sort']

--- a/src/lib/src/shared/ThFilter.svelte
+++ b/src/lib/src/shared/ThFilter.svelte
@@ -6,11 +6,12 @@
     type Props = {
         table  : TableHandlerInterface<T>,
         field  : Field<T>,
+        initValue ?: string,
         check ?: Check
     }
-    let { table, field, check = undefined }: Props = $props()
+    let { table, field, initValue = undefined, check = undefined }: Props = $props()
 
-    const filter = table.createFilter(field, check)
+    const filter = table.createFilter(field, initValue, check)
 </script>
 
 <th>

--- a/src/lib/src/shared/ThSort.svelte
+++ b/src/lib/src/shared/ThSort.svelte
@@ -6,11 +6,12 @@
     type Props = {
         table   : TableHandlerInterface<T>,
         field   : Field<T>,
+        init?: 'asc' | 'desc',
         children: Snippet
     }
-    let { table, field, children }: Props = $props()
+    let { table, field, init = undefined, children }: Props = $props()
 
-    const sort = table.createSort(field)
+    const sort = table.createSort(field, init)
 </script>
 
 <th onclick={() => sort.set()} class:active={sort.isActive}>

--- a/src/lib/src/shared/index.ts
+++ b/src/lib/src/shared/index.ts
@@ -25,10 +25,10 @@ export interface TableHandlerInterface<Row> {
     rowCount            : { selected: number, start: number, end: number, total: number }
     rowsPerPage         : number,
     clearSelection()    : void,
-    createSearch()      : { value: unknown, set(): void }
+    createSearch(): { value: unknown, set(): void }
     setPage(value?: number | 'previous' | 'next' | 'last'): void,
-    createFilter(field: Field<Row>, check?: Check): { value: unknown, set(): void },
-    createSort(field: Field<Row>): { isActive: boolean, direction: 'asc' | 'desc', set(): void }
+    createFilter(field: Field<Row>, value?: string, check?: Check): { value: unknown, set(): void },
+    createSort(field: Field<Row>, init?: 'asc' | 'desc'): { isActive: boolean, direction: 'asc' | 'desc', set(): void }
     on(event: string, callback: () => void): void 
 }
 


### PR DESCRIPTION
**Feature: Init values for sorting, filtering & search**  (#166)
Also fixes #167 

This PR adds three things:
- The ability to optionally add initialisation values for the search, filters as well as setting a default sorting (#166)
- It fixes the server-side search not resetting to page 1 (#167 )
- It adds an optional `invalidate` parameters to the `set()` methods of the server-side FilterBuilder and SearchBuilder, allowing for setting values without triggering invalidation

None of the default behaviour is altered.