### PR TITLE
fix: Removed console.log

### DIFF
--- a/src/lib/src/client/builders/CalculationBuilder.svelte.ts
+++ b/src/lib/src/client/builders/CalculationBuilder.svelte.ts
@@ -83,7 +83,6 @@ export default class CalcultationBuilder<Row>
 
     private round(value: number)
     {
-        console.log(value, typeof(value))
         return Number(value.toFixed(this.precision))
     }
 }


### PR DESCRIPTION
Removed console.log on CalculationBuilder, resulting in console logs on production pages when using a table footer with calulations.